### PR TITLE
Add interactive profile panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   </div>
 
   <div class="profile-panel" id="profilePanel">
+    <button id="closeProfilePanel" class="close-panel">&times;</button>
     <ul>
       <li><a href="/account.html">My Account</a></li>
       <li><a href="/messages.html">Messages</a></li>

--- a/script.js
+++ b/script.js
@@ -22,6 +22,17 @@ const mockCars = [
   { name: "Mazda CX-5", date: "2025-06-11", start: 68, end: 92 }
 ];
 
+function toggleProfilePanel() {
+  const panel = document.getElementById("profilePanel");
+  panel.classList.toggle("open");
+}
+
+function closeProfilePanel() {
+  document.getElementById("profilePanel").classList.remove("open");
+}
+
+window.toggleProfilePanel = toggleProfilePanel;
+
 function formatHour(block) {
   const hour = Math.floor(block / 4);
   const minutes = (block % 4) * 15;
@@ -144,4 +155,21 @@ document.addEventListener("DOMContentLoaded", () => {
   });
 
   rerenderAll();
+
+  const profileBox = document.getElementById("profileBox");
+  const closeBtn = document.getElementById("closeProfilePanel");
+  const panel = document.getElementById("profilePanel");
+
+  profileBox.addEventListener("click", (e) => {
+    e.stopPropagation();
+    toggleProfilePanel();
+  });
+
+  closeBtn.addEventListener("click", () => closeProfilePanel());
+
+  document.addEventListener("click", (e) => {
+    if (!panel.contains(e.target) && !profileBox.contains(e.target)) {
+      closeProfilePanel();
+    }
+  });
 });

--- a/style.css
+++ b/style.css
@@ -135,6 +135,25 @@ h1 {
   border-color: red;
 }
 
+.profile-box {
+  cursor: pointer;
+  background: var(--blue);
+  color: #fff;
+  padding: 0.25rem 0.75rem;
+  border-radius: var(--radius);
+}
+
+.close-panel {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  background: none;
+  border: none;
+  color: #fff;
+  font-size: 1.25rem;
+  cursor: pointer;
+}
+
 .profile-panel-toggle {
   position: fixed;
   top: 1rem;
@@ -163,6 +182,7 @@ h1 {
 
 .profile-panel.open {
   transform: translateX(0);
+  box-shadow: -2px 0 10px rgba(0, 0, 0, 0.3);
 }
 
 .login-screen {


### PR DESCRIPTION
## Summary
- add profile panel toggle logic in `script.js`
- close panel with document click or close button
- provide close button markup in `index.html`
- style `.profile-box` and enhance `.profile-panel.open` appearance

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841bb029a24832699ac42507163262f