### PR TITLE
Fix profile name storage and display

### DIFF
--- a/login.html
+++ b/login.html
@@ -20,7 +20,7 @@
       e.preventDefault();
       const name = document.getElementById('fullName').value.trim();
       if (name) {
-        sessionStorage.setItem('userFullName', name);
+        sessionStorage.setItem('fullName', name);
         window.location.href = '/'; // Redirect to home
       }
     });

--- a/script.js
+++ b/script.js
@@ -13,7 +13,7 @@ today.setHours(0, 0, 0, 0);
 
 const user = sessionStorage.getItem("fullName");
 if (!user) window.location.href = "/login.html";
-else document.getElementById("profileName").textContent = user;
+else document.getElementById("profileBox").textContent = user;
 
 const mockCars = [
   { name: "Toyota Corolla", date: "2025-06-10", start: 32, end: 56 },


### PR DESCRIPTION
## Summary
- fix login's sessionStorage key
- show user name in profile box

## Testing
- `npm install jsdom` *(fails: 403 Forbidden)*
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841bafb6e70832691a8e67a8d0f4fb9